### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/cyanboy/abacus/security/code-scanning/2](https://github.com/cyanboy/abacus/security/code-scanning/2)

To fix the issue, explicitly specify the minimal permissions required by the workflow, following the principle of least privilege. Since the workflow only performs code checkout, building, and testing (and no write operations to GitHub resources), the minimal required permission is `contents: read`. This can be applied at the workflow root level, which ensures all jobs inherit these restrictive permissions, unless otherwise overridden. Add a `permissions:` block after the `name` entry and before `on:` in `.github/workflows/ci.yml`, specifying `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
