### PR TITLE
feat: make recursion limit configurable and fail safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Options:
 - Disable ANSI colors for scripts or terminals that do not support them: add `--no-color` (e.g. `abc --no-color -e "1/3"`)
 - Color is also controlled by common environment variables: `NO_COLOR` disables color, `CLICOLOR_FORCE=1` forces it, and `CLICOLOR=0` disables it unless forced. Color is off when stdout is not a TTY unless forced.
 - Equality is type-strict: ints and floats cross-compare, but comparing booleans to numbers raises a type error instead of silently returning `false`.
+- Function calls have a recursion safeguard (default limit 1000, configurable via `--recursion-limit` or `ABACUS_MAX_CALL_DEPTH`); unbounded recursion (e.g., `inf(n) = n * inf(n)`) will eventually raise a recursion-limit diagnostic instead of looping forever.
 
 REPL sessions retain history, coloring, and diagnostic output between entries:
 

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -38,6 +38,14 @@ pub enum EvalError {
         #[label("division by zero")]
         span: Option<SourceSpan>,
     },
+
+    #[error("recursion limit ({limit}) exceeded in {name}")]
+    RecursionLimit {
+        name: String,
+        limit: usize,
+        #[label("too many recursive calls")]
+        span: Option<SourceSpan>,
+    },
 }
 
 impl EvalError {
@@ -75,6 +83,14 @@ impl EvalError {
         }
     }
 
+    pub fn recursion_limit(name: String, limit: usize, span: Span) -> Self {
+        Self::RecursionLimit {
+            name,
+            limit,
+            span: Some(span.into_source_span()),
+        }
+    }
+
     pub fn with_span(self, span: Span) -> Self {
         let span = Some(span.into_source_span());
         match self {
@@ -83,6 +99,9 @@ impl EvalError {
             EvalError::NoMatchingArm { name, .. } => EvalError::NoMatchingArm { name, span },
             EvalError::TypeError { message, .. } => EvalError::TypeError { message, span },
             EvalError::DivideByZero { .. } => EvalError::DivideByZero { span },
+            EvalError::RecursionLimit { name, limit, .. } => {
+                EvalError::RecursionLimit { name, limit, span }
+            }
         }
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,7 +1,8 @@
-mod engine;
+pub mod engine;
 pub mod error;
 pub mod values;
 
+pub use engine::DEFAULT_MAX_CALL_DEPTH;
 pub use engine::Env;
 pub use error::EvalError;
 pub use values::Value;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use clap::Parser;
 
-use abacus::{RunConfig, run_expression, run_file, run_with_config};
+use abacus::{
+    RunConfig, interpreter::DEFAULT_MAX_CALL_DEPTH, run_expression, run_file, run_with_config,
+};
 use std::process;
 
 #[derive(Parser, Debug)]
@@ -27,6 +29,14 @@ struct Cli {
     #[arg(long = "no-color")]
     no_color: bool,
 
+    /// Maximum recursion depth before aborting evaluation
+    #[arg(
+        long = "recursion-limit",
+        value_name = "DEPTH",
+        default_value_t = DEFAULT_MAX_CALL_DEPTH
+    )]
+    recursion_limit: usize,
+
     /// Execute the given Abacus source file
     #[arg(value_name = "FILE", conflicts_with = "expr")]
     script: Option<PathBuf>,
@@ -39,6 +49,7 @@ fn main() {
 fn run_cli(cli: Cli) -> i32 {
     let config = RunConfig {
         color: !cli.no_color,
+        recursion_limit: cli.recursion_limit,
     };
 
     if let Some(expr) = cli.expr {


### PR DESCRIPTION
- add --recursion-limit flag (default 1000) and env override for call depth
- enforce recursion caps in interpreter with user-configurable limit
- document recursion limit behavior and improve tests for color/style and recursion diagnostics
- Fixes #8